### PR TITLE
Refactor/video list re render

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react-player": "^2.10.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.7.4",
-    "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -47,8 +46,5 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "https://ginameee.github.io/bgm-controller",
-  "devDependencies": {
-    "@types/uuid": "^8.3.4"
-  }
+  "homepage": "https://ginameee.github.io/bgm-controller"
 }

--- a/src/components/organisms/VideoList.tsx
+++ b/src/components/organisms/VideoList.tsx
@@ -4,7 +4,6 @@ import { useAtom } from "jotai";
 import { urlsAtom } from "../../stores/videos";
 import VideoCard from "./VideoCard";
 import EmptyList from "../molecules/EmptyList";
-import { v4 as uuidv4 } from "uuid";
 
 function VideoList() {
   const [urls, setUrls] = useAtom(urlsAtom);
@@ -21,7 +20,7 @@ function VideoList() {
       ) : (
         <Grid container spacing={4}>
           {urls.map((url) => (
-            <Grid item xs={12} sm={6} md={3} key={uuidv4()}>
+            <Grid item xs={12} sm={6} md={3} key={url}>
               <Box sx={{ position: "relative" }}>
                 <Button
                   sx={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,11 +2248,6 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"


### PR DESCRIPTION
uuid를 사용할 경우 `key` 값이 매번 새로워지기때문에 아이템 단순 추가시에도 리스트가 모두 깜박이는 현상이 발생함.

## Solution

다른 유니크한 값을 추가하자!

#4 에서 중복 url을 추가하지 않기 때문에 list 내에서는 유니크한 값이라고 판단하여 url 사용!