### PR TITLE
fix: Video 초기 랜더 시, maxVolume 따라가지 않도록 수정

### DIFF
--- a/src/components/molecules/VolumeController.tsx
+++ b/src/components/molecules/VolumeController.tsx
@@ -14,12 +14,20 @@ const MAX_VALUE = 100;
 const MIN_VALUE = 0;
 
 function VolumeController({
-  defaultValue = MAX_VALUE,
+  defaultValue = MIN_VALUE,
   value,
   onVolumeChange,
   width = "100%",
 }: IProps) {
-  const [volume, setVolume] = useState<number>(defaultValue);
+  const [volume, setVolume] = useState<number>(() => {
+    if (defaultValue > MAX_VALUE) {
+      return MAX_VALUE;
+    }
+    if (defaultValue < MIN_VALUE) {
+      return MIN_VALUE;
+    }
+    return defaultValue;
+  });
   useEffect(() => {
     if (typeof value !== "undefined") {
       setVolume(value);

--- a/src/components/organisms/GlobalController.tsx
+++ b/src/components/organisms/GlobalController.tsx
@@ -94,7 +94,10 @@ function GlobalController() {
               width: { xs: 100, md: 100, xl: 250 },
             }}
           >
-            <VolumeController onVolumeChange={handleChangeVolume} />
+            <VolumeController
+              onVolumeChange={handleChangeVolume}
+              defaultValue={100}
+            />
           </Stack>
           <TextField
             label="Fade In/Out Time(ms)"

--- a/src/components/organisms/VideoCard.tsx
+++ b/src/components/organisms/VideoCard.tsx
@@ -18,7 +18,7 @@ interface IProps {
   isLoop?: boolean;
 }
 
-function VideoCard({ url, defaultVolume = 100, isLoop = true }: IProps) {
+function VideoCard({ url, defaultVolume = 0, isLoop = true }: IProps) {
   const [playing, setPlaying] = useState<boolean>(false);
   const playerRef = useRef<ReactPlayer>(null);
   const [currPlayedUrl, setCurrPlayedUrl] = useAtom(currPlayedUrlAtom);

--- a/src/hooks/useVolume.ts
+++ b/src/hooks/useVolume.ts
@@ -5,7 +5,7 @@ import { fadeInOutTimeAtom, volumeAtom } from "../stores/videos";
 const MIN_VOLUME = 0;
 const FADE_IN_OUT_UNIT = 2;
 
-function useVolume(defaultValue: number) {
+function useVolume(defaultValue: number = MIN_VOLUME) {
   const [volume, setVolume] = useState(defaultValue);
   const [fadeInOutTime] = useAtom(fadeInOutTimeAtom);
   const [maxVolume] = useAtom(volumeAtom);
@@ -61,8 +61,13 @@ function useVolume(defaultValue: number) {
     [clearVolumeFadeInOutTimer, startFadeInOut, maxVolume]
   );
 
+  const isFirstRenderRef = useRef(true);
   useEffect(() => {
-    setVolume(maxVolume);
+    if (!isFirstRenderRef.current) {
+      setVolume(maxVolume);
+    } else {
+      isFirstRenderRef.current = false;
+    }
     clearVolumeFadeInOutTimer();
   }, [maxVolume, clearVolumeFadeInOutTimer]);
 


### PR DESCRIPTION
- video 기본값 설정
- useVolume내에서 첫번째 masterVolume의 effect는 무시(=masterVolume 초기값 세팅)

ps. maxVolume을 최댓값으로만쓴다면 `isFirstRenderRef` 대신 현재 `volume` 값이랑 비교만 하면 될듯합니다!